### PR TITLE
fix(footer): corriger l'affichage du footer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,21 +27,21 @@
     </v-navigation-drawer>
 
     <v-main>
-      <v-container fluid style="max-width: 1300px" class="pa-8 mb-16">
+      <v-container fluid style="max-width: 1300px" class="pa-8">
         <router-view />
       </v-container>
     </v-main>
 
-    <v-footer absolute color="primary">
-      <v-col class="text-center" cols="12" md="6">
+    <v-footer app color="primary" class="d-flex flex-wrap justify-space-around py-6">
+      <div class="text-center">
         © {{ new Date().getFullYear() }} — <strong>Antoine Steyer</strong>
-      </v-col>
-      <v-col class="text-center" cols="12" md="6">
+      </div>
+      <div class="text-center">
         Made with
         <a href="https://github.com/vuejs/vue" rel="noopener noreferrer">Vue</a>
         and
         <a href="https://github.com/vuetifyjs/vuetify" rel="noopener noreferrer">Vuetify</a>
-      </v-col>
+      </div>
     </v-footer>
   </v-app>
 </template>


### PR DESCRIPTION
## Résumé

- Remplacement de `absolute` par le prop `app` sur `<v-footer>` pour intégrer le footer au système de layout de Vuetify 3 — v-main réserve désormais correctement l'espace bas et plus de zone vide sur les pages courtes.
- Suppression des `<v-col>` (utilisés hors `<v-row>`) au profit de simples `<div>` flex, et passage à `py-6` pour une hauteur de footer cohérente (~70px).
- Retrait du `mb-16` sur le container (workaround devenu inutile).

Closes #42

## Test plan

- [ ] Vérifier le rendu du footer sur la page Contact (peu de contenu)
- [ ] Vérifier le rendu sur la page Expériences (contenu long)
- [ ] Tester en mobile, tablette, desktop
- [ ] Vérifier qu'aucune page ne masque le bas du contenu

🤖 Generated with [Claude Code](https://claude.com/claude-code)