### PR TITLE
fix(mobile): improve formation and experience pages display

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,7 +32,7 @@
       </v-container>
     </v-main>
 
-    <v-footer app color="primary" class="d-flex flex-wrap justify-space-around py-6">
+    <v-footer app color="primary" class="d-flex flex-wrap justify-space-around ga-4 py-6">
       <div class="text-center">
         © {{ new Date().getFullYear() }} — <strong>Antoine Steyer</strong>
       </div>

--- a/src/components/TimelineSection.vue
+++ b/src/components/TimelineSection.vue
@@ -1,9 +1,47 @@
 <template>
-  <v-timeline
-    class="mt-10"
-    :density="smAndDown ? 'compact' : 'default'"
-    side="end"
-  >
+  <div v-if="smAndDown" class="d-flex flex-column ga-4 mt-10">
+    <v-card
+      v-for="entry in entries"
+      :key="entry.label + entry.year"
+      class="elevation-2"
+    >
+      <div class="px-4 pt-4">
+        <v-chip size="small" variant="tonal">
+          {{ entry.year }}
+        </v-chip>
+      </div>
+      <v-card-item>
+        <template v-if="entry.image" #prepend>
+          <v-avatar
+            :image="entry.image"
+            :alt="`Icône : ${entry.label}`"
+            size="40"
+          />
+        </template>
+        <v-card-title class="text-h6 text-wrap">
+          {{ entry.label }}
+        </v-card-title>
+        <v-card-subtitle>
+          <v-icon size="small" icon="mdi-map-marker" />
+          {{ entry.side }}
+        </v-card-subtitle>
+      </v-card-item>
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <v-card-text v-html="entry.description" />
+      <template v-if="entry.technos?.length">
+        <v-divider />
+        <v-card-actions>
+          <v-chip-group column>
+            <v-chip v-for="tech in entry.technos" :key="tech">
+              {{ tech }}
+            </v-chip>
+          </v-chip-group>
+        </v-card-actions>
+      </template>
+    </v-card>
+  </div>
+
+  <v-timeline v-else class="mt-10" side="end">
     <v-timeline-item
       v-for="entry in entries"
       :key="entry.label + entry.year"
@@ -26,7 +64,7 @@
         <template v-if="entry.technos?.length">
           <v-divider />
           <v-card-actions>
-            <v-chip-group>
+            <v-chip-group column>
               <v-chip v-for="tech in entry.technos" :key="tech">
                 {{ tech }}
               </v-chip>

--- a/src/theme/main.scss
+++ b/src/theme/main.scss
@@ -30,6 +30,10 @@
     .v-timeline:before {
       left: calc(50% - 5px);
     }
+
+    .v-card-text ul {
+      padding-inline-start: 1.5rem;
+    }
   }
 
   // Skill list


### PR DESCRIPTION
## Summary
- Replace `v-timeline` with stacked `v-card`s on mobile (`smAndDown`) so cards get the full width — the rail + icon was eating ~80px and the year was hidden by `density="compact"` anyway
- Year now displays as a small `v-chip` above the title; avatar stays in `v-card-item`'s prepend slot
- `column` added to all `v-chip-group`s so techno chips wrap instead of forcing horizontal overflow
- Restore `padding-inline-start` on `<ul>` inside timeline `v-card-text` (Vuetify reset removes it)
- `ga-4` on the footer so the copyright and "Made with" blocks have 16px gap when they wrap on mobile

Closes #40

## Test plan
- [x] Formation page renders correctly at 320 / 375 / 414px in light and dark mode
- [x] Experience page renders correctly at 320 / 375 / 414px in light and dark mode
- [x] Description `<ul>` bullets are indented properly
- [x] Techno chips wrap to multiple lines instead of overflowing
- [x] Desktop (`mdAndUp`) still uses the original `v-timeline` layout
- [x] Footer shows 16px gap between blocks when they wrap on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)