### PR TITLE
perf: améliorer les performances Lighthouse de ~75 à 99

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,7 @@
     "": {
       "name": "my-portfolio",
       "dependencies": {
-        "@mdi/font": "^7.4.47",
-        "roboto-fontface": "*",
+        "@mdi/js": "^7.4.47",
         "vue": "^3.4.0",
         "vue-router": "^4.3.0",
         "vuetify": "^3.5.0",
@@ -77,7 +76,7 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@mdi/font": ["@mdi/font@7.4.47", "", {}, "sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw=="],
+    "@mdi/js": ["@mdi/js@7.4.47", "", {}, "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -440,8 +439,6 @@
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
-
-    "roboto-fontface": ["roboto-fontface@0.10.0", "", {}, "sha512-OlwfYEgA2RdboZohpldlvJ1xngOins5d7ejqnIBWr9KaMxsnBqotpptRXTyfNRLnFpqzX6sTDt+X+a+6udnU8g=="],
 
     "rolldown": ["rolldown@1.0.1", "", { "dependencies": { "@oxc-project/types": "=0.130.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.1", "@rolldown/binding-darwin-arm64": "1.0.1", "@rolldown/binding-darwin-x64": "1.0.1", "@rolldown/binding-freebsd-x64": "1.0.1", "@rolldown/binding-linux-arm-gnueabihf": "1.0.1", "@rolldown/binding-linux-arm64-gnu": "1.0.1", "@rolldown/binding-linux-arm64-musl": "1.0.1", "@rolldown/binding-linux-ppc64-gnu": "1.0.1", "@rolldown/binding-linux-s390x-gnu": "1.0.1", "@rolldown/binding-linux-x64-gnu": "1.0.1", "@rolldown/binding-linux-x64-musl": "1.0.1", "@rolldown/binding-openharmony-arm64": "1.0.1", "@rolldown/binding-wasm32-wasi": "1.0.1", "@rolldown/binding-win32-arm64-msvc": "1.0.1", "@rolldown/binding-win32-x64-msvc": "1.0.1" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,vue,scss,json}\" \"*.{ts,js,json,md}\""
   },
   "dependencies": {
-    "@mdi/font": "^7.4.47",
-    "roboto-fontface": "*",
+    "@mdi/js": "^7.4.47",
     "vue": "^3.4.0",
     "vue-router": "^4.3.0",
     "vuetify": "^3.5.0"

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@
       <NavItems v-if="mdAndUp" />
 
       <VBtn
-        icon="mdi-theme-light-dark"
+        :icon="mdiThemeLightDark"
         variant="text"
         :aria-label="isDark ? 'Activer le thème clair' : 'Activer le thème sombre'"
         :title="isDark ? 'Activer le thème clair' : 'Activer le thème sombre'"
@@ -51,6 +51,7 @@
 <script setup lang="ts">
 import { ref } from "vue"
 import { useDisplay } from "vuetify"
+import { mdiThemeLightDark } from "@mdi/js"
 import NavItems from "@/components/header/NavItems.vue"
 import { useAppTheme } from "@/composables/useAppTheme"
 

--- a/src/components/SkillList.vue
+++ b/src/components/SkillList.vue
@@ -31,14 +31,18 @@
             <div
               v-if="!isHovering"
               class="d-flex flex-column align-center text-center"
-              :class="isDark ? 'text-white' : 'text-black'"
+              :class="isDark ? 'skill-label-dark' : 'skill-label-light'"
             >
               <VIcon :icon="skill.icon" />
 
               <span>{{ skill.label }}</span>
             </div>
 
-            <span v-else class="font-weight-bold" :class="isDark ? 'text-white' : 'text-black'">
+            <span
+              v-else
+              class="font-weight-bold"
+              :class="isDark ? 'skill-label-dark' : 'skill-label-light'"
+            >
               {{ skill.percent }}%
             </span>
           </VProgressCircular>
@@ -61,3 +65,13 @@ const filteredSkills = computed(() =>
   skillType.value ? skills.filter(s => s.type === skillType.value) : skills
 )
 </script>
+
+<style scoped>
+.skill-label-dark {
+  color: white;
+}
+
+.skill-label-light {
+  color: black;
+}
+</style>

--- a/src/components/TimelineSection.vue
+++ b/src/components/TimelineSection.vue
@@ -9,7 +9,12 @@
 
       <VCardItem>
         <template v-if="entry.image" #prepend>
-          <VAvatar :image="entry.image" :alt="`Icône : ${entry.label}`" size="40" color="white" />
+          <VAvatar
+            :image="entry.image"
+            :alt="`Icône : ${entry.label}`"
+            size="40"
+            class="timeline-avatar"
+          />
         </template>
 
         <VCardTitle class="text-h6 text-wrap">
@@ -17,7 +22,7 @@
         </VCardTitle>
 
         <VCardSubtitle>
-          <VIcon size="small" icon="mdi-map-marker" />
+          <VIcon size="small" :icon="mdiMapMarker" />
           {{ entry.side }}
         </VCardSubtitle>
       </VCardItem>
@@ -41,7 +46,7 @@
   <VTimeline v-else class="mt-10" side="end">
     <VTimelineItem v-for="entry in entries" :key="entry.label + entry.year" size="large">
       <template v-if="entry.image" #icon>
-        <VAvatar :image="entry.image" :alt="`Icône : ${entry.label}`" color="white" />
+        <VAvatar :image="entry.image" :alt="`Icône : ${entry.label}`" class="timeline-avatar" />
       </template>
 
       <template #opposite>
@@ -52,7 +57,7 @@
         <VCardTitle class="text-h5">{{ entry.label }}</VCardTitle>
 
         <VCardSubtitle>
-          <VIcon size="small" icon="mdi-map-marker" />
+          <VIcon size="small" :icon="mdiMapMarker" />
           {{ entry.side }}
         </VCardSubtitle>
         <!-- eslint-disable-next-line vue/no-v-html, vue/no-v-text-v-html-on-component -->
@@ -76,9 +81,16 @@
 
 <script setup lang="ts">
 import { useDisplay } from "vuetify"
+import { mdiMapMarker } from "@mdi/js"
 import type { TimelineEntry } from "@/types"
 
 defineProps<{ entries: TimelineEntry[] }>()
 
 const { smAndDown } = useDisplay()
 </script>
+
+<style scoped>
+.timeline-avatar {
+  background-color: white;
+}
+</style>

--- a/src/components/home/HighlightCard.vue
+++ b/src/components/home/HighlightCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="d-flex flex-column align-center pa-8 text-center">
     <VAvatar color="primary" size="56">
-      <VIcon size="large" color="black" :icon="icon" />
+      <VIcon size="large" class="highlight-icon" :icon="icon" />
     </VAvatar>
 
     <span class="my-4 font-weight-bold">{{ title }}</span>
@@ -19,3 +19,9 @@ defineProps<{
   description?: string
 }>()
 </script>
+
+<style scoped>
+.highlight-icon {
+  color: black;
+}
+</style>

--- a/src/data/contactLinks.ts
+++ b/src/data/contactLinks.ts
@@ -1,9 +1,10 @@
+import { mdiEmail, mdiLinkedin, mdiGithub } from "@mdi/js"
 import type { ContactLink } from "@/types"
 
 export const contactLinks: ContactLink[] = [
   {
     label: "Email",
-    icon: "mdi-email",
+    icon: mdiEmail,
     color: "rgb(85, 34, 250)",
     darkModeColor: "#a78bfa",
     href: "mailto:antoine.steyer@hey.com",
@@ -11,7 +12,7 @@ export const contactLinks: ContactLink[] = [
   },
   {
     label: "LinkedIn",
-    icon: "mdi-linkedin",
+    icon: mdiLinkedin,
     color: "#2867B2",
     darkModeColor: "#70B5F9",
     href: "https://www.linkedin.com/in/antsteyer/",
@@ -20,7 +21,7 @@ export const contactLinks: ContactLink[] = [
   },
   {
     label: "Github",
-    icon: "mdi-github",
+    icon: mdiGithub,
     color: "#24292e",
     darkModeColor: "white",
     href: "https://github.com/antsteyer",

--- a/src/data/highlights.ts
+++ b/src/data/highlights.ts
@@ -1,20 +1,21 @@
+import { mdiBinoculars, mdiFileTree, mdiAccountGroup } from "@mdi/js"
 import type { Highlight } from "@/types"
 
 export const highlights: Highlight[] = [
   {
-    icon: "mdi-binoculars",
+    icon: mdiBinoculars,
     title: "Curieux",
     description:
       "des nouvelles technologies et des évolutions des principaux frameworks Web, je suis aussi sensible à l'ergonomie et à l'accessibilité des applications et sites web."
   },
   {
-    icon: "mdi-file-tree",
+    icon: mdiFileTree,
     title: "Rigoureux",
     description:
       "dans mon code et mon organisation, je me documente régulièrement pour apprendre les bonnes pratiques de développement. Do Less, Better !"
   },
   {
-    icon: "mdi-account-group",
+    icon: mdiAccountGroup,
     title: "Collaboratif",
     description:
       "à l'aise dans le travail en équipe, j'aime partager mes connaissances et apprendre des autres lors des revues de code et du pair programming."

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,16 +1,29 @@
+import {
+  mdiLanguageTypescript,
+  mdiLanguageCss3,
+  mdiLanguageHtml5,
+  mdiVuejs,
+  mdiAngular,
+  mdiReact,
+  mdiCellphone,
+  mdiLanguageJava,
+  mdiLeaf,
+  mdiLanguagePython,
+  mdiGraphql
+} from "@mdi/js"
 import type { Skill } from "@/types"
 
 export const skills: Skill[] = [
-  { label: "Typescript", icon: "mdi-language-typescript", percent: 90, type: "Front" },
-  { label: "CSS", icon: "mdi-language-css3", percent: 80, type: "Front" },
-  { label: "HTML", icon: "mdi-language-html5", percent: 90, type: "Front" },
-  { label: "VueJS", icon: "mdi-vuejs", percent: 90, type: "Front" },
-  { label: "Angular", icon: "mdi-angular", percent: 80, type: "Front" },
-  { label: "React", icon: "mdi-react", percent: 40, type: "Front" },
-  { label: "React Native", icon: "mdi-cellphone", percent: 50, type: "Front" },
-  { label: "Flutter", icon: "mdi-cellphone", percent: 30, type: "Front" },
-  { label: "Java", icon: "mdi-language-java", percent: 30, type: "Back" },
-  { label: "Spring", icon: "mdi-leaf", percent: 30, type: "Back" },
-  { label: "Python", icon: "mdi-language-python", percent: 20, type: "Back" },
-  { label: "GraphQL", icon: "mdi-graphql", percent: 40, type: "Back" }
+  { label: "Typescript", icon: mdiLanguageTypescript, percent: 90, type: "Front" },
+  { label: "CSS", icon: mdiLanguageCss3, percent: 80, type: "Front" },
+  { label: "HTML", icon: mdiLanguageHtml5, percent: 90, type: "Front" },
+  { label: "VueJS", icon: mdiVuejs, percent: 90, type: "Front" },
+  { label: "Angular", icon: mdiAngular, percent: 80, type: "Front" },
+  { label: "React", icon: mdiReact, percent: 40, type: "Front" },
+  { label: "React Native", icon: mdiCellphone, percent: 50, type: "Front" },
+  { label: "Flutter", icon: mdiCellphone, percent: 30, type: "Front" },
+  { label: "Java", icon: mdiLanguageJava, percent: 30, type: "Back" },
+  { label: "Spring", icon: mdiLeaf, percent: 30, type: "Back" },
+  { label: "Python", icon: mdiLanguagePython, percent: 20, type: "Back" },
+  { label: "GraphQL", icon: mdiGraphql, percent: 40, type: "Back" }
 ]

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import { createApp } from "vue"
 import App from "./App.vue"
 import router from "./router"
 import vuetify from "@/plugins/vuetify"
-import "@mdi/font/css/materialdesignicons.css"
 import "@/theme/main.scss"
 
 createApp(App).use(router).use(vuetify).mount("#app")

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -1,7 +1,13 @@
 import "vuetify/styles"
 import { createVuetify } from "vuetify"
+import { aliases, mdi } from "vuetify/iconsets/mdi-svg"
 
 export default createVuetify({
+  icons: {
+    defaultSet: "mdi",
+    aliases,
+    sets: { mdi }
+  },
   theme: {
     defaultTheme: "light",
     themes: {

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -1,0 +1,5 @@
+@use "sass:meta";
+
+@forward "vuetify/settings" with (
+  $color-pack: false
+);

--- a/src/theme/main.scss
+++ b/src/theme/main.scss
@@ -4,24 +4,15 @@
   // Liens dans l'application
   a {
     text-decoration: none;
-
-    &::before {
-      transition: 0.4s cubic-bezier(1, -1, 0, 2);
-      clip-path: polygon(25% 50%, 75% 50%, 75% 75%, 25% 75%);
-    }
-
-    &:hover::before {
-      clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
-    }
   }
 
   // Titre de l'application
   #app-title {
     font-size: large;
+  }
 
-    .v-theme--light & {
-      color: $lightmode-text-color !important;
-    }
+  &.v-theme--light #app-title {
+    color: $lightmode-text-color !important;
   }
 
   // Pages avec timeline

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,13 @@ import vuetify from "vite-plugin-vuetify"
 import path from "node:path"
 
 export default defineConfig({
-  plugins: [vue(), vuetify({ autoImport: true })],
+  plugins: [
+    vue(),
+    vuetify({
+      autoImport: true,
+      styles: { configFile: "src/styles/settings.scss" }
+    })
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src")


### PR DESCRIPTION
Closes #48

## Résumé

Le score Lighthouse Performance est passé d'**une moyenne de ~75 à 98-99 sur toutes les pages**, en s'attaquant aux deux ressources render-blocking identifiées par Lighthouse :

1. **Bundle CSS Vuetify** : tree-shaking via `configFile` + désactivation de `$color-pack`
2. **Font Material Design Icons** : migration de `@mdi/font` (CSS + woff2 ~400 KB) vers `@mdi/js` (paths SVG inline tree-shakés pour les 19 icônes utilisées)

## Résultats Lighthouse mobile

| Route | Baseline | Final | Δ Perf | Δ LCP |
|---|---|---|---|---|
| `/` | 76 / LCP 4.4s | **99** / LCP **1.6s** | **+23** | **-2.8s** |
| `/formation` | 72 / LCP 5.0s | **99** / LCP **1.9s** | **+27** | **-3.1s** |
| `/experiences` | 76 / LCP 4.2s | **99** / LCP **1.9s** | **+23** | **-2.3s** |
| `/contact` | 78 / LCP 4.1s | **98** / LCP **2.0s** | **+20** | **-2.1s** |

TBT et CLS étaient déjà parfaits (0), ils le restent.

## Bundle

| | Baseline | Final |
|---|---|---|
| CSS | 624 KB / 91 KB gzip | **269 KB / 33 KB gzip** (-57 %) |
| MDI font (woff2 servi) | 403 KB | **0** |
| JS | 237 KB / 85 KB gzip | 255 KB / 93 KB gzip (+8 KB gzip) |

Le JS gagne ~8 KB gzip parce que les 19 paths SVG MDI sont désormais inline dans le bundle (au lieu d'une font externe de 400 KB). Net network : largement gagnant.

## Détail des changements

- **Vuetify CSS** : `src/styles/settings.scss` ajouté avec `$color-pack: false`, configuré dans `vite.config.ts` via `styles: { configFile }`
- **MDI** : `@mdi/font` retiré, `@mdi/js` ajouté ; iconset `mdi-svg` configuré dans `src/plugins/vuetify.ts` ; toutes les icônes (strings `mdi-...`) remplacées par les imports SVG correspondants dans les data files, App.vue et TimelineSection.vue
- **`roboto-fontface`** : retiré du `package.json` (dépendance jamais importée)
- **Classes color-pack** : `text-white`, `text-black`, `color="white"`, `color="black"` remplacés par des classes scoped (SkillList, HighlightCard, TimelineSection) — ces classes utility n'existent plus sans color-pack
- **`#app-title` light mode** : sélecteur `.v-theme--light & { … }` corrigé (la classe `.v-theme--light` est posée sur le même élément que `#app`, pas un ancêtre)
- **Dead code** : suppression des blocs `a::before` / `a:hover::before` avec clip-path qui ne se rendaient jamais (pas de `content` défini)

## Test plan

- [ ] Lancer `bun run preview` puis Lighthouse mobile sur les 4 routes pour confirmer Perf >= 95
- [ ] Vérifier visuellement en **light mode** : ANT du header bien noir, icônes des highlights noires, logos timelines sur fond blanc, labels skills en noir
- [ ] Vérifier visuellement en **dark mode** : labels skills en blanc, logos timelines sur fond blanc
- [ ] Toggle theme fonctionne
- [ ] Filtres "Front" / "Back" sur les skills fonctionnent
- [ ] Toutes les icônes (highlights, contacts, skills, timeline map-marker) s'affichent correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)