### PR TITLE
feat(i18n): add fr/en internationalization with vue-i18n

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@mdi/js": "^7.4.47",
         "vue": "^3.4.0",
+        "vue-i18n": "^11",
         "vue-router": "^4.3.0",
         "vuetify": "^3.5.0",
       },
@@ -73,6 +74,14 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@intlify/core-base": ["@intlify/core-base@11.4.2", "", { "dependencies": { "@intlify/devtools-types": "11.4.2", "@intlify/message-compiler": "11.4.2", "@intlify/shared": "11.4.2" } }, "sha512-7fpuCcVmeLv2T9qHsARqGvh8xt+sV2fH+Q+gMHFwB/rPXzo85DpbJFKn7dBH1L5p0c2cSh2DW+2h/64EKrISmA=="],
+
+    "@intlify/devtools-types": ["@intlify/devtools-types@11.4.2", "", { "dependencies": { "@intlify/core-base": "11.4.2", "@intlify/shared": "11.4.2" } }, "sha512-3u8EN1kB6EMSi96KXs5k7a8y2X2g4+h3X6iwVZU47cP4n+mTuq//WMjG588BzSp/2XQ/dTXo2BLUXX+XS+PNfA=="],
+
+    "@intlify/message-compiler": ["@intlify/message-compiler@11.4.2", "", { "dependencies": { "@intlify/shared": "11.4.2", "source-map-js": "^1.0.2" } }, "sha512-a6CDSGSMTGrg0BjD97x8TBYPf7qQMDlZipJ6UDfv/pd4OIym8TMlHu3MsH0bTNnRdAG2D6EFEykIgiQPqvtTkA=="],
+
+    "@intlify/shared": ["@intlify/shared@11.4.2", "", {}, "sha512-NzpHbguRCsOHDwxmlBa9qu/imc+/QWgsYUaK6FZeNC0wK8QfAbhqrktEp/haVzxU1aikH8IX4ytD+mfFEMi/9A=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
@@ -491,6 +500,8 @@
     "vue": ["vue@3.5.34", "", { "dependencies": { "@vue/compiler-dom": "3.5.34", "@vue/compiler-sfc": "3.5.34", "@vue/runtime-dom": "3.5.34", "@vue/server-renderer": "3.5.34", "@vue/shared": "3.5.34" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA=="],
 
     "vue-eslint-parser": ["vue-eslint-parser@10.4.0", "", { "dependencies": { "debug": "^4.4.0", "eslint-scope": "^8.2.0 || ^9.0.0", "eslint-visitor-keys": "^4.2.0 || ^5.0.0", "espree": "^10.3.0 || ^11.0.0", "esquery": "^1.6.0", "semver": "^7.6.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0" } }, "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg=="],
+
+    "vue-i18n": ["vue-i18n@11.4.2", "", { "dependencies": { "@intlify/core-base": "11.4.2", "@intlify/devtools-types": "11.4.2", "@intlify/shared": "11.4.2", "@vue/devtools-api": "^6.5.0" }, "peerDependencies": { "vue": "^3.0.0" } }, "sha512-sADDeKXqAGsPX6tK3t3y2ZiMpbVWN12tG+MhTiJ06rVoh58eGtM4wFyw3uWGbVkXByVp9Ne/AP+nSSzI+J9OAQ=="],
 
     "vue-router": ["vue-router@4.6.4", "", { "dependencies": { "@vue/devtools-api": "^6.6.4" }, "peerDependencies": { "vue": "^3.5.0" } }, "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg=="],
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@mdi/js": "^7.4.47",
     "vue": "^3.4.0",
+    "vue-i18n": "^11",
     "vue-router": "^4.3.0",
     "vuetify": "^3.5.0"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,15 +1,9 @@
 <template>
   <VApp id="app">
-    <a href="#main-content" class="skip-link"> Aller au contenu principal </a>
+    <a href="#main-content" class="skip-link">{{ t("header.skipToContent") }}</a>
 
     <VAppBar elevate-on-scroll>
-      <VBtn
-        id="app-title"
-        variant="text"
-        color="primary"
-        to="/"
-        aria-label="ANT, retour à l'accueil"
-      >
+      <VBtn id="app-title" variant="text" color="primary" to="/" :aria-label="t('header.homeAria')">
         ANT
       </VBtn>
 
@@ -17,18 +11,20 @@
 
       <NavItems v-if="mdAndUp" />
 
+      <LocaleSwitcher class="mx-2" />
+
       <VBtn
         :icon="mdiThemeLightDark"
         variant="text"
-        :aria-label="isDark ? 'Activer le thème clair' : 'Activer le thème sombre'"
-        :title="isDark ? 'Activer le thème clair' : 'Activer le thème sombre'"
+        :aria-label="isDark ? t('header.themeToLight') : t('header.themeToDark')"
+        :title="isDark ? t('header.themeToLight') : t('header.themeToDark')"
         @click="toggle"
       />
 
       <VAppBarNavIcon
         v-if="!mdAndUp"
-        aria-label="Ouvrir le menu de navigation"
-        title="Ouvrir le menu de navigation"
+        :aria-label="t('header.openMenu')"
+        :title="t('header.openMenu')"
         @click.stop="drawer = !drawer"
       />
     </VAppBar>
@@ -48,12 +44,15 @@
         © {{ new Date().getFullYear() }} — <strong>Antoine Steyer</strong>
       </div>
 
-      <div class="text-center">
-        Made with
-        <a href="https://github.com/vuejs/core" rel="noopener noreferrer">Vue</a>
-        and
-        <a href="https://github.com/vuetifyjs/vuetify" rel="noopener noreferrer">Vuetify</a>
-      </div>
+      <I18nT keypath="footer.madeWith" tag="div" class="text-center" scope="global">
+        <template #vue>
+          <a href="https://github.com/vuejs/core" rel="noopener noreferrer">Vue</a>
+        </template>
+
+        <template #vuetify>
+          <a href="https://github.com/vuetifyjs/vuetify" rel="noopener noreferrer">Vuetify</a>
+        </template>
+      </I18nT>
     </VFooter>
   </VApp>
 </template>
@@ -61,11 +60,14 @@
 <script setup lang="ts">
 import { ref } from "vue"
 import { useDisplay } from "vuetify"
+import { useI18n, I18nT } from "vue-i18n"
 import { mdiThemeLightDark } from "@mdi/js"
 import NavItems from "@/components/header/NavItems.vue"
+import LocaleSwitcher from "@/components/header/LocaleSwitcher.vue"
 import { useAppTheme } from "@/composables/useAppTheme"
 
 const { mdAndUp } = useDisplay()
 const { isDark, toggle } = useAppTheme()
+const { t } = useI18n()
 const drawer = ref(false)
 </script>

--- a/src/components/SkillList.vue
+++ b/src/components/SkillList.vue
@@ -5,7 +5,7 @@
       role="group"
       aria-labelledby="skill-filter-label"
     >
-      <span id="skill-filter-label">Filtrer par :</span>
+      <span id="skill-filter-label">{{ t("skills.filterBy") }}</span>
 
       <VChipGroup v-model="skillType" color="primary" selected-class="text-on-primary">
         <VChip
@@ -16,7 +16,7 @@
           :value="type"
           :variant="skillType === type ? 'flat' : 'tonal'"
         >
-          {{ type }}
+          {{ t(`skills.types.${type}`) }}
         </VChip>
       </VChipGroup>
     </div>
@@ -32,7 +32,7 @@
               :model-value="skill.percent"
               color="primary"
               class="ma-6"
-              :aria-label="`${skill.label}, niveau de maîtrise ${skill.percent}%`"
+              :aria-label="t('skills.levelAria', { label: skill.label, percent: skill.percent })"
             >
               <div
                 v-if="!isHovering"
@@ -63,10 +63,12 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue"
+import { useI18n } from "vue-i18n"
 import { skills } from "@/data/skills"
 import { SKILL_TYPES, type SkillType } from "@/types"
 import { useAppTheme } from "@/composables/useAppTheme"
 
+const { t } = useI18n()
 const { isDark } = useAppTheme()
 const skillType = ref<SkillType | null>(null)
 

--- a/src/components/TimelineEntryBody.vue
+++ b/src/components/TimelineEntryBody.vue
@@ -1,0 +1,31 @@
+<template>
+  <p v-if="intro">{{ intro }}</p>
+
+  <ul v-if="bullets.length">
+    <li v-for="(bullet, index) in bullets" :key="index">{{ bullet }}</li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+import { useI18n } from "vue-i18n"
+
+const props = defineProps<{
+  namespace: string
+  entryKey: string
+}>()
+
+const { tm, locale } = useI18n({ useScope: "global" })
+
+const intro = computed<string | null>(() => {
+  void locale.value
+  const raw = tm(`${props.namespace}.${props.entryKey}.intro`) as unknown
+  return typeof raw === "string" ? raw : null
+})
+
+const bullets = computed<string[]>(() => {
+  void locale.value
+  const raw = tm(`${props.namespace}.${props.entryKey}.bullets`) as unknown
+  return Array.isArray(raw) ? (raw as string[]) : []
+})
+</script>

--- a/src/components/TimelineSection.vue
+++ b/src/components/TimelineSection.vue
@@ -1,9 +1,9 @@
 <template>
   <div v-if="smAndDown" class="d-flex flex-column ga-4 mt-10">
-    <VCard v-for="entry in entries" :key="entry.label + entry.year" class="elevation-2">
+    <VCard v-for="entry in entries" :key="entry.key" class="elevation-2">
       <div class="px-4 pt-4">
         <VChip size="small" variant="tonal">
-          {{ entry.year }}
+          {{ t(`${namespace}.${entry.key}.year`) }}
         </VChip>
       </div>
 
@@ -11,67 +11,75 @@
         <template v-if="entry.image" #prepend>
           <VAvatar
             :image="entry.image"
-            :alt="`Icône : ${entry.label}`"
+            :alt="t('timeline.iconAlt', { label: t(`${namespace}.${entry.key}.label`) })"
             size="40"
             class="timeline-avatar"
           />
         </template>
 
         <VCardTitle tag="h2" class="text-h6 text-wrap">
-          {{ entry.label }}
+          {{ t(`${namespace}.${entry.key}.label`) }}
         </VCardTitle>
 
         <VCardSubtitle>
           <VIcon size="small" :icon="mdiMapMarker" />
-          {{ entry.side }}
+          {{ t(`${namespace}.${entry.key}.side`) }}
         </VCardSubtitle>
       </VCardItem>
-      <!-- eslint-disable-next-line vue/no-v-html, vue/no-v-text-v-html-on-component -->
-      <VCardText v-html="entry.description" />
+
+      <VCardText>
+        <TimelineEntryBody :namespace="namespace" :entry-key="entry.key" />
+      </VCardText>
 
       <template v-if="entry.technos?.length">
         <VDivider />
 
         <VCardActions>
-          <div class="d-flex flex-wrap ga-2">
-            <VChip v-for="tech in entry.technos" :key="tech" tag="span">
+          <ul class="d-flex flex-wrap ga-2 technos">
+            <VChip v-for="tech in entry.technos" :key="tech" tag="li">
               {{ tech }}
             </VChip>
-          </div>
+          </ul>
         </VCardActions>
       </template>
     </VCard>
   </div>
 
   <VTimeline v-else class="mt-10" side="end">
-    <VTimelineItem v-for="entry in entries" :key="entry.label + entry.year" size="large">
+    <VTimelineItem v-for="entry in entries" :key="entry.key" size="large">
       <template v-if="entry.image" #icon>
-        <VAvatar :image="entry.image" :alt="`Icône : ${entry.label}`" class="timeline-avatar" />
+        <VAvatar
+          :image="entry.image"
+          :alt="t('timeline.iconAlt', { label: t(`${namespace}.${entry.key}.label`) })"
+          class="timeline-avatar"
+        />
       </template>
 
       <template #opposite>
-        <span class="font-weight-bold">{{ entry.year }}</span>
+        <span class="font-weight-bold">{{ t(`${namespace}.${entry.key}.year`) }}</span>
       </template>
 
       <VCard class="elevation-2">
-        <VCardTitle tag="h2" class="text-h5">{{ entry.label }}</VCardTitle>
+        <VCardTitle tag="h2" class="text-h5">{{ t(`${namespace}.${entry.key}.label`) }}</VCardTitle>
 
         <VCardSubtitle>
           <VIcon size="small" :icon="mdiMapMarker" />
-          {{ entry.side }}
+          {{ t(`${namespace}.${entry.key}.side`) }}
         </VCardSubtitle>
-        <!-- eslint-disable-next-line vue/no-v-html, vue/no-v-text-v-html-on-component -->
-        <VCardText v-html="entry.description" />
+
+        <VCardText>
+          <TimelineEntryBody :namespace="namespace" :entry-key="entry.key" />
+        </VCardText>
 
         <template v-if="entry.technos?.length">
           <VDivider />
 
           <VCardActions>
-            <div class="d-flex flex-wrap ga-2">
-              <VChip v-for="tech in entry.technos" :key="tech" tag="span">
+            <ul class="d-flex flex-wrap ga-2 technos">
+              <VChip v-for="tech in entry.technos" :key="tech" tag="li">
                 {{ tech }}
               </VChip>
-            </div>
+            </ul>
           </VCardActions>
         </template>
       </VCard>
@@ -81,16 +89,28 @@
 
 <script setup lang="ts">
 import { useDisplay } from "vuetify"
+import { useI18n } from "vue-i18n"
 import { mdiMapMarker } from "@mdi/js"
 import type { TimelineEntry } from "@/types"
+import TimelineEntryBody from "@/components/TimelineEntryBody.vue"
 
-defineProps<{ entries: TimelineEntry[] }>()
+defineProps<{
+  entries: TimelineEntry[]
+  namespace: string
+}>()
 
 const { smAndDown } = useDisplay()
+const { t } = useI18n()
 </script>
 
 <style scoped>
 .timeline-avatar {
   background-color: white;
+}
+
+.technos {
+  list-style: none;
+  padding-inline-start: 0;
+  margin: 0;
 }
 </style>

--- a/src/components/header/LocaleSwitcher.vue
+++ b/src/components/header/LocaleSwitcher.vue
@@ -1,0 +1,39 @@
+<template>
+  <VBtnToggle
+    :model-value="locale"
+    mandatory
+    density="comfortable"
+    color="primary"
+    divided
+    class="locale-switcher"
+    :aria-label="t('header.localeSwitcher')"
+    @update:model-value="onChange"
+  >
+    <VBtn
+      v-for="code in SUPPORTED_LOCALES"
+      :key="code"
+      :value="code"
+      :lang="code"
+      size="small"
+      :variant="locale === code ? 'flat' : 'outlined'"
+      :class="{ 'font-weight-bold': locale === code }"
+      :aria-pressed="locale === code"
+      selected-class="text-on-primary"
+    >
+      {{ code.toUpperCase() }}
+    </VBtn>
+  </VBtnToggle>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+import { useI18n } from "vue-i18n"
+import { SUPPORTED_LOCALES, setLocale, type AppLocale } from "@/i18n"
+
+const { t, locale: i18nLocale } = useI18n()
+const locale = computed(() => i18nLocale.value as AppLocale)
+
+function onChange(value: AppLocale | null): void {
+  if (value && value !== locale.value) setLocale(value)
+}
+</script>

--- a/src/components/header/NavItems.vue
+++ b/src/components/header/NavItems.vue
@@ -1,14 +1,16 @@
 <template>
-  <nav :class="{ 'd-flex flex-column': smAndDown }" aria-label="Navigation principale">
+  <nav :class="{ 'd-flex flex-column': smAndDown }" :aria-label="t('header.mainNav')">
     <VBtn v-for="item in navItems" :key="item.to" class="ma-2" variant="text" :to="item.to">
-      {{ item.label }}
+      {{ t(`nav.${item.key}`) }}
     </VBtn>
   </nav>
 </template>
 
 <script setup lang="ts">
 import { useDisplay } from "vuetify"
+import { useI18n } from "vue-i18n"
 import { navItems } from "@/data/navItems"
 
 const { smAndDown } = useDisplay()
+const { t } = useI18n()
 </script>

--- a/src/data/contactLinks.ts
+++ b/src/data/contactLinks.ts
@@ -3,29 +3,26 @@ import type { ContactLink } from "@/types"
 
 export const contactLinks: ContactLink[] = [
   {
-    label: "Email",
+    key: "email",
     icon: mdiEmail,
     color: "rgb(85, 34, 250)",
     darkModeColor: "#a78bfa",
-    href: "mailto:antoine.steyer@hey.com",
-    funnyCatchPhrase: "Je lis mes mails quotidiennement"
+    href: "mailto:antoine.steyer@hey.com"
   },
   {
-    label: "LinkedIn",
+    key: "linkedin",
     icon: mdiLinkedin,
     color: "#2867B2",
     darkModeColor: "#70B5F9",
     href: "https://www.linkedin.com/in/antsteyer/",
-    funnyCatchPhrase: "Merci de ne pas m'envoyer de message préconçu sans âme ni personnalisation",
     external: true
   },
   {
-    label: "Github",
+    key: "github",
     icon: mdiGithub,
     color: "#24292e",
     darkModeColor: "white",
     href: "https://github.com/antsteyer",
-    funnyCatchPhrase: "Mon humble contribution à l'open-source",
     external: true
   }
 ]

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -2,60 +2,27 @@ import type { TimelineEntry } from "@/types"
 
 export const experiences: TimelineEntry[] = [
   {
-    label: "Développeur Front-End",
-    year: "Février 2023 à Aujourd'hui",
-    side: "Agorize, Paris",
-    description:
-      "<ul>" +
-      "<li>Développer de nouvelles fonctionnalités sur l'application Vue SPA et SSR</li>" +
-      "<li>Migrer de Vue 2 à Vue 3 (et passage de Webpack à Vite)</li>" +
-      "<li>Rendre l'application accessible en respectant le WCAG AA</li>" +
-      "</ul>",
+    key: "agorize",
     image: "/img/logos/agorize.webp",
     technos: ["Vue 2 et 3", "Accessibilité", "SSR", "Node.js", "Express", "AWS", "Docker"]
   },
   {
-    label: "Développeur Front-End",
-    year: "Juillet 2022 à Janvier 2023",
-    side: "Myre, Lyon",
-    description:
-      "<ul>" +
-      "<li>Développer de nouvelles fonctionnalités</li>" +
-      "<li>Concevoir, créer et intégrer de nouveaux modules cross-app Angular</li>" +
-      "<li>Optimiser les performances des modules Angular</li>" +
-      "</ul>",
+    key: "myre",
     image: "/img/logos/myre.webp",
     technos: ["Angular", "Storybook", "Node.js", "AWS", "Docker"]
   },
   {
-    label: "Développeur Full-Stack",
-    year: "Octobre 2019 à Juin 2022",
-    side: "Klee Group, Lyon",
-    description:
-      "<ul>" +
-      "<li>Développer de nouvelles fonctionnalités full-stack pour différents clients du secteur public</li>" +
-      "<li>Participer aux réflexions UX/UI et animer les cérémonies en tant que Scrum Master</li>" +
-      "</ul>",
+    key: "kleeGroup",
     image: "/img/logos/klee-group.webp",
     technos: ["Angular (8 à 12)", "Spring", "Scrum", "Figma"]
   },
   {
-    label: "Apprentissage",
-    year: "Septembre 2018 à Septembre 2019",
-    side: "Radioactiv'IT, Sophia Antipolis",
-    description:
-      "<ul>" +
-      "<li>Concevoir et implémenter l'interface utilisateur d'un outil de Business Intelligence</li>" +
-      "<li>Développements ponctuels sur applications mobiles ou web de clients</li>" +
-      "</ul>",
+    key: "radioactivit",
     image: "/img/logos/radioactivit.webp",
     technos: ["VueJS", "NestJS", "GraphQL", "Flutter", "React Native"]
   },
   {
-    label: "Stage",
-    year: "Juin et Juillet 2017",
-    side: "OPAC Savoie, Chambéry",
-    description: "Développer des scripts d'automatisation de tâches métiers en Java et Python.",
+    key: "opacSavoie",
     image: "/img/logos/opac-savoie.webp",
     technos: ["Java", "Python"]
   }

--- a/src/data/formations.ts
+++ b/src/data/formations.ts
@@ -1,26 +1,7 @@
 import type { TimelineEntry } from "@/types"
 
 export const formations: TimelineEntry[] = [
-  {
-    year: "2015-2019",
-    side: "Polytech' Nice Sophia",
-    label: "Diplômes Ingénieur et Master Informatique",
-    description:
-      "Double diplôme : <ul><li>Ingénieur en Sciences Informatiques, spécialité Interfaces Homme-Machine</li><li>Master Informatique et Ingénierie (IFI) en apprentissage</li></ul>",
-    image: "/img/logos/polytech.svg"
-  },
-  {
-    year: "2013-2015",
-    side: "Polytech' Annecy Chambéry",
-    label: "PeiP - Option Informatique",
-    description: "Parcours des écoles d'ingénieurs Polytech.",
-    image: "/img/logos/polytech.svg"
-  },
-  {
-    year: "2013",
-    side: "Lycée Vaugelas - Chambéry",
-    label: "BAC S - SVT",
-    description: "Mention Bien.",
-    image: "/img/vaugelas.webp"
-  }
+  { key: "polytechNice", image: "/img/logos/polytech.svg" },
+  { key: "polytechAnnecy", image: "/img/logos/polytech.svg" },
+  { key: "vaugelas", image: "/img/vaugelas.webp" }
 ]

--- a/src/data/highlights.ts
+++ b/src/data/highlights.ts
@@ -2,22 +2,7 @@ import { mdiBinoculars, mdiFileTree, mdiAccountGroup } from "@mdi/js"
 import type { Highlight } from "@/types"
 
 export const highlights: Highlight[] = [
-  {
-    icon: mdiBinoculars,
-    title: "Curieux",
-    description:
-      "des nouvelles technologies et des évolutions des principaux frameworks Web, je suis aussi sensible à l'ergonomie et à l'accessibilité des applications et sites web."
-  },
-  {
-    icon: mdiFileTree,
-    title: "Rigoureux",
-    description:
-      "dans mon code et mon organisation, je me documente régulièrement pour apprendre les bonnes pratiques de développement. Do Less, Better !"
-  },
-  {
-    icon: mdiAccountGroup,
-    title: "Collaboratif",
-    description:
-      "à l'aise dans le travail en équipe, j'aime partager mes connaissances et apprendre des autres lors des revues de code et du pair programming."
-  }
+  { key: "curious", icon: mdiBinoculars },
+  { key: "rigorous", icon: mdiFileTree },
+  { key: "collaborative", icon: mdiAccountGroup }
 ]

--- a/src/data/navItems.ts
+++ b/src/data/navItems.ts
@@ -1,7 +1,7 @@
 import type { NavItem } from "@/types"
 
 export const navItems: NavItem[] = [
-  { label: "Formation", to: "/formation" },
-  { label: "Expériences", to: "/experiences" },
-  { label: "Contact", to: "/contact" }
+  { key: "formation", to: "/formation" },
+  { key: "experiences", to: "/experiences" },
+  { key: "contact", to: "/contact" }
 ]

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,49 @@
+import { createI18n } from "vue-i18n"
+import fr from "./locales/fr.json"
+import en from "./locales/en.json"
+
+export const SUPPORTED_LOCALES = ["fr", "en"] as const
+export type AppLocale = (typeof SUPPORTED_LOCALES)[number]
+
+const STORAGE_KEY = "portfolio:locale"
+const DEFAULT_LOCALE: AppLocale = "fr"
+
+function isSupported(value: string | null | undefined): value is AppLocale {
+  return !!value && (SUPPORTED_LOCALES as readonly string[]).includes(value)
+}
+
+function detectLocale(): AppLocale {
+  if (typeof window === "undefined") return DEFAULT_LOCALE
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  if (isSupported(stored)) return stored
+  const navLang = window.navigator.language?.split("-")[0]
+  if (isSupported(navLang)) return navLang
+  return DEFAULT_LOCALE
+}
+
+export const i18n = createI18n<false>({
+  legacy: false,
+  locale: detectLocale(),
+  fallbackLocale: DEFAULT_LOCALE,
+  messages: { fr, en }
+})
+
+function applyDocumentLocale(locale: string): void {
+  if (typeof document === "undefined") return
+  document.documentElement.lang = locale
+  const description = i18n.global.t("meta.description")
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="description"]')
+  if (meta) meta.content = description
+}
+
+export function setLocale(locale: AppLocale): void {
+  i18n.global.locale.value = locale
+  if (typeof window !== "undefined") {
+    window.localStorage.setItem(STORAGE_KEY, locale)
+  }
+  applyDocumentLocale(locale)
+}
+
+export function initLocale(): void {
+  applyDocumentLocale(i18n.global.locale.value)
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,156 @@
+{
+  "common": {
+    "siteName": "Antoine Steyer"
+  },
+  "nav": {
+    "formation": "Education",
+    "experiences": "Experience",
+    "contact": "Contact"
+  },
+  "header": {
+    "homeAria": "ANT, back to home",
+    "skipToContent": "Skip to main content",
+    "themeToLight": "Switch to light theme",
+    "themeToDark": "Switch to dark theme",
+    "openMenu": "Open navigation menu",
+    "mainNav": "Main navigation",
+    "localeSwitcher": "Change language"
+  },
+  "footer": {
+    "madeWith": "Made with {vue} and {vuetify}"
+  },
+  "meta": {
+    "home": "Home",
+    "formation": "Education",
+    "experience": "Experience",
+    "contact": "Contact",
+    "description": "Antoine Steyer's portfolio — Full Stack engineer and Front-End developer passionate about user experience."
+  },
+  "home": {
+    "title": "Hi, I'm Antoine 👦🏻",
+    "intro1": "I'm {age} years old, I currently live in Valence (France), but I'm originally from Savoie.",
+    "intro2": "Trained as an engineer in Human-Computer Interaction, I work mostly on Front-End development, with a particular focus on web accessibility. I strive to design inclusive, intuitive and performant interfaces, built for everyone.",
+    "skillsTitle": "My skills 📚"
+  },
+  "formation": {
+    "title": "It's a long story 🎓"
+  },
+  "experience": {
+    "title": "I've contributed to these projects 💼"
+  },
+  "contact": {
+    "title": "Let's stay in touch! 📫",
+    "intro": "Whether you just want to say hi or you'd like to work with me, feel free to drop me a line by email or on one of the networks below. I'd be glad to chat!",
+    "linkAria": "Open {label}",
+    "linkAriaExternal": "Open {label} (new window)"
+  },
+  "skills": {
+    "filterBy": "Filter by:",
+    "types": {
+      "Front": "Front",
+      "Back": "Back"
+    },
+    "levelAria": "{label}, proficiency level {percent}%"
+  },
+  "timeline": {
+    "iconAlt": "Icon: {label}"
+  },
+  "contactLinks": {
+    "email": {
+      "label": "Email",
+      "funnyCatchPhrase": "I check my inbox every day"
+    },
+    "linkedin": {
+      "label": "LinkedIn",
+      "funnyCatchPhrase": "Please don't send me a soulless boilerplate message"
+    },
+    "github": {
+      "label": "Github",
+      "funnyCatchPhrase": "My humble contribution to open-source"
+    }
+  },
+  "highlights": {
+    "curious": {
+      "title": "Curious",
+      "description": "about new technologies and the evolution of major web frameworks; I also care deeply about the ergonomics and accessibility of apps and websites."
+    },
+    "rigorous": {
+      "title": "Rigorous",
+      "description": "in my code and my organisation, I regularly read up on development best practices. Do Less, Better!"
+    },
+    "collaborative": {
+      "title": "Collaborative",
+      "description": "comfortable working in a team, I enjoy sharing what I know and learning from others through code reviews and pair programming."
+    }
+  },
+  "formations": {
+    "polytechNice": {
+      "year": "2015-2019",
+      "side": "Polytech' Nice Sophia",
+      "label": "Engineering & Master's degree in Computer Science",
+      "intro": "Dual degree:",
+      "bullets": [
+        "Engineering degree in Computer Science, Human-Computer Interaction specialty",
+        "Master's in Computer Science & Engineering (IFI), apprenticeship track"
+      ]
+    },
+    "polytechAnnecy": {
+      "year": "2013-2015",
+      "side": "Polytech' Annecy Chambéry",
+      "label": "PeiP - Computer Science track",
+      "intro": "Preparatory cycle for the Polytech engineering schools."
+    },
+    "vaugelas": {
+      "year": "2013",
+      "side": "Lycée Vaugelas - Chambéry",
+      "label": "French Baccalauréat S - SVT",
+      "intro": "Passed with honours (Mention Bien)."
+    }
+  },
+  "experiences": {
+    "agorize": {
+      "year": "February 2023 – Present",
+      "side": "Agorize, Paris",
+      "label": "Front-End Developer",
+      "bullets": [
+        "Build new features on the Vue SPA and SSR application",
+        "Migrate the codebase from Vue 2 to Vue 3 (and from Webpack to Vite)",
+        "Make the application accessible to WCAG AA standards"
+      ]
+    },
+    "myre": {
+      "year": "July 2022 – January 2023",
+      "side": "Myre, Lyon",
+      "label": "Front-End Developer",
+      "bullets": [
+        "Build new features",
+        "Design, build and integrate new cross-app Angular modules",
+        "Optimise the performance of Angular modules"
+      ]
+    },
+    "kleeGroup": {
+      "year": "October 2019 – June 2022",
+      "side": "Klee Group, Lyon",
+      "label": "Full-Stack Developer",
+      "bullets": [
+        "Build new full-stack features for various public-sector clients",
+        "Contribute to UX/UI design and facilitate ceremonies as Scrum Master"
+      ]
+    },
+    "radioactivit": {
+      "year": "September 2018 – September 2019",
+      "side": "Radioactiv'IT, Sophia Antipolis",
+      "label": "Apprenticeship",
+      "bullets": [
+        "Design and implement the user interface of a Business Intelligence tool",
+        "Ad-hoc development on clients' mobile and web applications"
+      ]
+    },
+    "opacSavoie": {
+      "year": "June – July 2017",
+      "side": "OPAC Savoie, Chambéry",
+      "label": "Internship",
+      "intro": "Build business-task automation scripts in Java and Python."
+    }
+  }
+}

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1,0 +1,156 @@
+{
+  "common": {
+    "siteName": "Antoine Steyer"
+  },
+  "nav": {
+    "formation": "Formation",
+    "experiences": "Expériences",
+    "contact": "Contact"
+  },
+  "header": {
+    "homeAria": "ANT, retour à l'accueil",
+    "skipToContent": "Aller au contenu principal",
+    "themeToLight": "Activer le thème clair",
+    "themeToDark": "Activer le thème sombre",
+    "openMenu": "Ouvrir le menu de navigation",
+    "mainNav": "Navigation principale",
+    "localeSwitcher": "Changer de langue"
+  },
+  "footer": {
+    "madeWith": "Réalisé avec {vue} et {vuetify}"
+  },
+  "meta": {
+    "home": "Accueil",
+    "formation": "Formation",
+    "experience": "Expériences",
+    "contact": "Contact",
+    "description": "Portfolio d'Antoine Steyer — Ingénieur Full Stack et développeur Front-End passionné par l'expérience utilisateur."
+  },
+  "home": {
+    "title": "Salut, moi c'est Antoine 👦🏻",
+    "intro1": "J'ai {age} ans, je réside actuellement à Valence, mais je suis originaire de Savoie.",
+    "intro2": "De formation Ingénieur en Interfaces Homme-Machine, je travaille principalement en développement Front-End, avec une attention particulière pour l'accessibilité du web. Je m'attache à concevoir des interfaces inclusives, intuitives et performantes, pensées pour tous les utilisateurs.",
+    "skillsTitle": "Mes savoir-faire 📚"
+  },
+  "formation": {
+    "title": "C'est une longue histoire 🎓"
+  },
+  "experience": {
+    "title": "J'ai apporté ma pierre à ces édifices 💼"
+  },
+  "contact": {
+    "title": "Ne nous perdons pas de vue ! 📫",
+    "intro": "Si tu veux simplement me dire bonjour ou si tu as envie de travailler avec moi, n'hésite pas à me laisser un petit mot par email ou sur l'un de mes réseaux ci-dessous. Je serai ravi d'échanger avec toi !",
+    "linkAria": "Accéder à {label}",
+    "linkAriaExternal": "Accéder à {label} (nouvelle fenêtre)"
+  },
+  "skills": {
+    "filterBy": "Filtrer par :",
+    "types": {
+      "Front": "Front",
+      "Back": "Back"
+    },
+    "levelAria": "{label}, niveau de maîtrise {percent}%"
+  },
+  "timeline": {
+    "iconAlt": "Icône : {label}"
+  },
+  "contactLinks": {
+    "email": {
+      "label": "Email",
+      "funnyCatchPhrase": "Je lis mes mails quotidiennement"
+    },
+    "linkedin": {
+      "label": "LinkedIn",
+      "funnyCatchPhrase": "Merci de ne pas m'envoyer de message préconçu sans âme ni personnalisation"
+    },
+    "github": {
+      "label": "Github",
+      "funnyCatchPhrase": "Mon humble contribution à l'open-source"
+    }
+  },
+  "highlights": {
+    "curious": {
+      "title": "Curieux",
+      "description": "des nouvelles technologies et des évolutions des principaux frameworks Web, je suis aussi sensible à l'ergonomie et à l'accessibilité des applications et sites web."
+    },
+    "rigorous": {
+      "title": "Rigoureux",
+      "description": "dans mon code et mon organisation, je me documente régulièrement pour apprendre les bonnes pratiques de développement. Do Less, Better !"
+    },
+    "collaborative": {
+      "title": "Collaboratif",
+      "description": "à l'aise dans le travail en équipe, j'aime partager mes connaissances et apprendre des autres lors des revues de code et du pair programming."
+    }
+  },
+  "formations": {
+    "polytechNice": {
+      "year": "2015-2019",
+      "side": "Polytech' Nice Sophia",
+      "label": "Diplômes Ingénieur et Master Informatique",
+      "intro": "Double diplôme :",
+      "bullets": [
+        "Ingénieur en Sciences Informatiques, spécialité Interfaces Homme-Machine",
+        "Master Informatique et Ingénierie (IFI) en apprentissage"
+      ]
+    },
+    "polytechAnnecy": {
+      "year": "2013-2015",
+      "side": "Polytech' Annecy Chambéry",
+      "label": "PeiP - Option Informatique",
+      "intro": "Parcours des écoles d'ingénieurs Polytech."
+    },
+    "vaugelas": {
+      "year": "2013",
+      "side": "Lycée Vaugelas - Chambéry",
+      "label": "BAC S - SVT",
+      "intro": "Mention Bien."
+    }
+  },
+  "experiences": {
+    "agorize": {
+      "year": "Février 2023 à Aujourd'hui",
+      "side": "Agorize, Paris",
+      "label": "Développeur Front-End",
+      "bullets": [
+        "Développer de nouvelles fonctionnalités sur l'application Vue SPA et SSR",
+        "Migrer de Vue 2 à Vue 3 (et passage de Webpack à Vite)",
+        "Rendre l'application accessible en respectant le WCAG AA"
+      ]
+    },
+    "myre": {
+      "year": "Juillet 2022 à Janvier 2023",
+      "side": "Myre, Lyon",
+      "label": "Développeur Front-End",
+      "bullets": [
+        "Développer de nouvelles fonctionnalités",
+        "Concevoir, créer et intégrer de nouveaux modules cross-app Angular",
+        "Optimiser les performances des modules Angular"
+      ]
+    },
+    "kleeGroup": {
+      "year": "Octobre 2019 à Juin 2022",
+      "side": "Klee Group, Lyon",
+      "label": "Développeur Full-Stack",
+      "bullets": [
+        "Développer de nouvelles fonctionnalités full-stack pour différents clients du secteur public",
+        "Participer aux réflexions UX/UI et animer les cérémonies en tant que Scrum Master"
+      ]
+    },
+    "radioactivit": {
+      "year": "Septembre 2018 à Septembre 2019",
+      "side": "Radioactiv'IT, Sophia Antipolis",
+      "label": "Apprentissage",
+      "bullets": [
+        "Concevoir et implémenter l'interface utilisateur d'un outil de Business Intelligence",
+        "Développements ponctuels sur applications mobiles ou web de clients"
+      ]
+    },
+    "opacSavoie": {
+      "year": "Juin et Juillet 2017",
+      "side": "OPAC Savoie, Chambéry",
+      "label": "Stage",
+      "intro": "Développer des scripts d'automatisation de tâches métiers en Java et Python."
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,9 @@ import { createApp } from "vue"
 import App from "./App.vue"
 import router from "./router"
 import vuetify from "@/plugins/vuetify"
+import { i18n, initLocale } from "@/i18n"
 import "@/theme/main.scss"
 
-createApp(App).use(router).use(vuetify).mount("#app")
+initLocale()
+
+createApp(App).use(i18n).use(router).use(vuetify).mount("#app")

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -1,8 +1,14 @@
 import "vuetify/styles"
 import { createVuetify } from "vuetify"
 import { aliases, mdi } from "vuetify/iconsets/mdi-svg"
+import { createVueI18nAdapter } from "vuetify/locale/adapters/vue-i18n"
+import { useI18n } from "vue-i18n"
+import { i18n } from "@/i18n"
 
 export default createVuetify({
+  locale: {
+    adapter: createVueI18nAdapter({ i18n, useI18n })
+  },
   icons: {
     defaultSet: "mdi",
     aliases,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,27 +1,27 @@
+import { watch } from "vue"
 import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router"
 import HomeView from "../views/HomeView.vue"
-
-const SITE_NAME = "Antoine Steyer"
+import { i18n } from "@/i18n"
 
 const routes: RouteRecordRaw[] = [
-  { path: "/", name: "Home", component: HomeView, meta: { title: "Accueil" } },
+  { path: "/", name: "Home", component: HomeView, meta: { titleKey: "meta.home" } },
   {
     path: "/formation",
     name: "Formation",
     component: () => import("../views/FormationView.vue"),
-    meta: { title: "Formation" }
+    meta: { titleKey: "meta.formation" }
   },
   {
     path: "/experiences",
     name: "Experience",
     component: () => import("../views/ExperienceView.vue"),
-    meta: { title: "Expériences" }
+    meta: { titleKey: "meta.experience" }
   },
   {
     path: "/contact",
     name: "Contact",
     component: () => import("../views/ContactView.vue"),
-    meta: { title: "Contact" }
+    meta: { titleKey: "meta.contact" }
   }
 ]
 
@@ -30,9 +30,13 @@ const router = createRouter({
   routes
 })
 
-router.afterEach(to => {
-  const pageTitle = to.meta.title as string | undefined
-  document.title = pageTitle ? `${pageTitle} — ${SITE_NAME}` : SITE_NAME
-})
+function applyDocumentTitle(): void {
+  const titleKey = router.currentRoute.value.meta.titleKey as string | undefined
+  const siteName = i18n.global.t("common.siteName")
+  document.title = titleKey ? `${i18n.global.t(titleKey)} — ${siteName}` : siteName
+}
+
+router.afterEach(applyDocumentTitle)
+watch(i18n.global.locale, applyDocumentTitle)
 
 export default router

--- a/src/theme/_color.scss
+++ b/src/theme/_color.scss
@@ -1,3 +1,3 @@
-// Thème — Vuetify 3 expose les couleurs via `rgb(var(--v-theme-<name>))`
+// Theme — Vuetify 3 exposes colors via `rgb(var(--v-theme-<name>))`
 $primary: rgb(var(--v-theme-primary));
 $lightmode-text-color: black;

--- a/src/theme/main.scss
+++ b/src/theme/main.scss
@@ -1,6 +1,6 @@
 @use "color" as *;
 
-// Skip link — visible uniquement quand focus
+// Skip link — only visible when focused
 .skip-link {
   position: absolute;
   top: 0;
@@ -21,7 +21,7 @@
   }
 }
 
-// Respect des préférences utilisateur de mouvement réduit
+// Honor the user's reduced-motion preference
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -33,18 +33,18 @@
   }
 }
 
-// Évite le contour de focus visible sur le wrapper VMain (rendu programmatiquement)
+// Hide the visible focus ring on the VMain wrapper (focused programmatically)
 #main-content:focus {
   outline: none;
 }
 
 #app {
-  // Liens dans l'application
+  // App-wide links
   a {
     text-decoration: none;
   }
 
-  // Titre de l'application
+  // App title
   #app-title {
     font-size: large;
   }
@@ -53,7 +53,7 @@
     color: $lightmode-text-color !important;
   }
 
-  // Pages avec timeline
+  // Timeline-based pages
   #formation,
   #experience {
     .v-timeline:before {
@@ -81,6 +81,11 @@
     }
   }
 
+  // Locale switcher — drop the active-button overlay that drags contrast below WCAG AA
+  .locale-switcher .v-btn--active .v-btn__overlay {
+    opacity: 0;
+  }
+
   // Footer
   footer.v-footer {
     a {
@@ -89,7 +94,7 @@
     }
   }
 
-  // Styles transverses
+  // Cross-cutting styles
   .v-card-title {
     word-break: break-word;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,5 @@
 export interface TimelineEntry {
-  year: string
-  label: string
-  description: string
-  /** Side information: location for a formation, company for an experience. */
-  side: string
+  key: string
   image?: string
   technos?: string[]
 }
@@ -19,23 +15,21 @@ export const SKILL_TYPES = ["Front", "Back"] as const
 export type SkillType = (typeof SKILL_TYPES)[number]
 
 export interface ContactLink {
-  label: string
+  key: string
   icon: string
   color: string
   darkModeColor?: string
   href: string
-  funnyCatchPhrase: string
   /** When true, open in a new tab with safe rel attributes. */
   external?: boolean
 }
 
 export interface NavItem {
-  label: string
+  key: string
   to: string
 }
 
 export interface Highlight {
+  key: string
   icon: string
-  title: string
-  description: string
 }

--- a/src/views/ContactView.vue
+++ b/src/views/ContactView.vue
@@ -1,22 +1,18 @@
 <template>
   <section class="contact">
-    <h1>Ne nous perdons pas de vue ! 📫</h1>
+    <h1>{{ t("contact.title") }}</h1>
 
-    <p class="mt-10">
-      Si tu veux simplement me dire bonjour ou si tu as envie de travailler avec moi, n'hésite pas à
-      me laisser un petit mot par email ou sur l'un de mes réseaux ci-dessous. Je serai ravi
-      d'échanger avec toi !
-    </p>
+    <p class="mt-10">{{ t("contact.intro") }}</p>
 
     <VCard class="mt-10" width="fit-content">
       <VCardText>
         <ul class="d-flex flex-column flex-md-row justify-center align-center contact-links">
-          <li v-for="link in contactLinks" :key="link.label">
+          <li v-for="link in contactLinks" :key="link.key">
             <VTooltip
               location="bottom"
               attach="#main-content"
-              :text="link.funnyCatchPhrase"
-              :aria-label="link.funnyCatchPhrase"
+              :text="t(`contactLinks.${link.key}.funnyCatchPhrase`)"
+              :aria-label="t(`contactLinks.${link.key}.funnyCatchPhrase`)"
             >
               <template #activator="{ props: activatorProps }">
                 <VBtn
@@ -28,12 +24,14 @@
                   :color="colorFor(link)"
                   :aria-label="
                     link.external
-                      ? `Accéder à ${link.label} (nouvelle fenêtre)`
-                      : `Accéder à ${link.label}`
+                      ? t('contact.linkAriaExternal', {
+                          label: t(`contactLinks.${link.key}.label`)
+                        })
+                      : t('contact.linkAria', { label: t(`contactLinks.${link.key}.label`) })
                   "
                 >
                   <VIcon start :icon="link.icon" />
-                  {{ link.label }}
+                  {{ t(`contactLinks.${link.key}.label`) }}
                 </VBtn>
               </template>
             </VTooltip>
@@ -45,10 +43,12 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from "vue-i18n"
 import { useAppTheme } from "@/composables/useAppTheme"
 import { contactLinks } from "@/data/contactLinks"
 import type { ContactLink } from "@/types"
 
+const { t } = useI18n()
 const { isDark } = useAppTheme()
 
 function colorFor(link: ContactLink): string {

--- a/src/views/ExperienceView.vue
+++ b/src/views/ExperienceView.vue
@@ -1,12 +1,15 @@
 <template>
   <section id="experience">
-    <h1>J'ai apporté ma pierre à ces édifices 💼</h1>
+    <h1>{{ t("experience.title") }}</h1>
 
-    <TimelineSection :entries="experiences" />
+    <TimelineSection :entries="experiences" namespace="experiences" />
   </section>
 </template>
 
 <script setup lang="ts">
+import { useI18n } from "vue-i18n"
 import TimelineSection from "@/components/TimelineSection.vue"
 import { experiences } from "@/data/experiences"
+
+const { t } = useI18n()
 </script>

--- a/src/views/FormationView.vue
+++ b/src/views/FormationView.vue
@@ -1,12 +1,15 @@
 <template>
   <section id="formation">
-    <h1>C'est une longue histoire 🎓</h1>
+    <h1>{{ t("formation.title") }}</h1>
 
-    <TimelineSection :entries="formations" />
+    <TimelineSection :entries="formations" namespace="formations" />
   </section>
 </template>
 
 <script setup lang="ts">
+import { useI18n } from "vue-i18n"
 import TimelineSection from "@/components/TimelineSection.vue"
 import { formations } from "@/data/formations"
+
+const { t } = useI18n()
 </script>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,32 +1,25 @@
 <template>
   <section id="home">
-    <h1>Salut, moi c'est Antoine 👦🏻</h1>
+    <h1>{{ t("home.title") }}</h1>
 
     <div class="my-10 text-body-1">
-      <p>
-        J'ai {{ age }} ans, je réside actuellement à Valence, mais je suis originaire de Savoie.
-      </p>
+      <p>{{ t("home.intro1", { age }) }}</p>
 
-      <p>
-        De formation Ingénieur en Interfaces Homme-Machine, je travaille principalement en
-        développement Front-End, avec une attention particulière pour l'accessibilité du web. Je
-        m'attache à concevoir des interfaces inclusives, intuitives et performantes, pensées pour
-        tous les utilisateurs.
-      </p>
+      <p>{{ t("home.intro2") }}</p>
 
       <VRow class="mt-4" align="start">
-        <VCol v-for="highlight in highlights" :key="highlight.title" cols="12" md="4">
+        <VCol v-for="highlight in highlights" :key="highlight.key" cols="12" md="4">
           <HighlightCard
             :icon="highlight.icon"
-            :title="highlight.title"
-            :description="highlight.description"
+            :title="t(`highlights.${highlight.key}.title`)"
+            :description="t(`highlights.${highlight.key}.description`)"
           />
         </VCol>
       </VRow>
     </div>
 
     <section>
-      <h2>Mes savoir-faire 📚</h2>
+      <h2>{{ t("home.skillsTitle") }}</h2>
 
       <SkillList />
     </section>
@@ -34,10 +27,12 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from "vue-i18n"
 import SkillList from "@/components/SkillList.vue"
 import HighlightCard from "@/components/home/HighlightCard.vue"
 import { highlights } from "@/data/highlights"
 import { useAge } from "@/composables/useAge"
 
+const { t } = useI18n()
 const age = useAge(new Date("1995-03-05"))
 </script>


### PR DESCRIPTION
Closes #41.

## Summary
- Wires vue-i18n@11 (Composition API) with Vuetify's locale adapter.
- Detects locale from `localStorage` → `navigator.language` → fallback `fr`; persists to `localStorage` and syncs `<html lang>`, `<meta description>` and `document.title` on every change.
- Extracts every UI string into `src/i18n/locales/fr.json` and `en.json`, organised by namespace (`nav`, `header`, `home`, `formation`, `experience`, `contact`, `skills`, `timeline`, `meta`, `highlights`, `formations`, `experiences`, `contactLinks`).
- Refactors `src/data/*` to expose stable keys only (`key`, `icon`, `image`, `href`, …); localized labels/descriptions live in the locale files.
- Replaces inline HTML descriptions (`<ul><li>…</li></ul>` rendered with `v-html`) with structured `intro` (string) + `bullets` (array) handled by the new `TimelineEntryBody` component — no more `v-html`.
- Adds a `LocaleSwitcher` (VBtnToggle, FR/EN, in the app bar on both desktop and mobile drawer) with `lang` attribute on each button for screen readers.
- Overrides the Vuetify active-button overlay on the switcher to keep contrast above WCAG AA in dark mode (black bold on `#26946f` measured at 5.56:1 vs ~4.45:1 with the default 12% overlay).

## Test plan
- [x] Toggle FR ↔ EN — every page (Home, Formation, Experiences, Contact) updates without reload
- [x] Reload — selected locale persists
- [x] Open in a browser with `navigator.language = 'en-US'` and no stored locale → starts in EN
- [x] `document.title`, `<html lang>` and `<meta description>` update on locale change
- [x] Mobile drawer + desktop nav both show the switcher
- [x] Timeline descriptions (intro and bullets) render correctly on Formation and Experiences, mobile and desktop
- [x] Re-run Lighthouse — accessibility stays at 100 on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)