### PR TITLE
fix(theme): corriger le warning de dépréciation Vuetify sur theme.global.name.value

### DIFF
--- a/src/composables/useAppTheme.ts
+++ b/src/composables/useAppTheme.ts
@@ -22,9 +22,9 @@ export function useAppTheme() {
   const theme = useTheme()
 
   if (!initialized) {
-    theme.global.name.value = getPreferredTheme()
+    theme.change(getPreferredTheme())
     watch(
-      () => theme.global.name.value,
+      () => theme.name.value,
       name => {
         if (typeof window !== "undefined") {
           window.localStorage.setItem(STORAGE_KEY, name)
@@ -34,10 +34,10 @@ export function useAppTheme() {
     initialized = true
   }
 
-  const isDark = computed(() => theme.global.current.value.dark)
+  const isDark = computed(() => theme.current.value.dark)
 
   function toggle() {
-    theme.global.name.value = isDark.value ? "light" : "dark"
+    theme.change(isDark.value ? "light" : "dark")
   }
 
   return { isDark, toggle }


### PR DESCRIPTION
## Résumé

- Remplace les assignations dépréciées `theme.global.name.value = ...` par l'API `theme.change(...)`
- Bascule la lecture vers les refs top-level `theme.name` et `theme.current`
- Supprime le warning `[Vuetify UPGRADE]` émis au runtime

Closes #54

## Plan de test

- [x] Lancer `bun run dev`, vérifier qu'aucun warning `[Vuetify UPGRADE]` n'apparaît dans la console
- [x] Premier chargement : le thème respecte `prefers-color-scheme`
- [x] Toggle light → dark → light fonctionne et persiste dans `localStorage`
- [x] Recharger la page : le thème stocké est bien réappliqué