### PR TITLE
fix(seo): dedupe Person JSON-LD across SSR and client hydration

### DIFF
--- a/src/config/jsonld.ts
+++ b/src/config/jsonld.ts
@@ -1,0 +1,13 @@
+import { SITE_URL } from "@/config/site"
+import fr from "@/i18n/locales/fr.json"
+
+export const personJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Antoine Steyer",
+  url: SITE_URL,
+  jobTitle: fr.seo.jobTitle,
+  description: fr.seo.personDescription,
+  address: { "@type": "PostalAddress", addressLocality: "Valence", addressCountry: "FR" },
+  sameAs: ["https://www.linkedin.com/in/antsteyer/", "https://github.com/antsteyer"]
+} as const

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -27,7 +27,6 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue"
 import { useI18n } from "vue-i18n"
 import { useHead } from "@unhead/vue"
 import SkillList from "@/components/SkillList.vue"
@@ -35,7 +34,7 @@ import HighlightCard from "@/components/home/HighlightCard.vue"
 import { highlights } from "@/data/highlights"
 import { useAge } from "@/composables/useAge"
 import { useRouteSeo } from "@/composables/useRouteSeo"
-import { SITE_URL } from "@/config/site"
+import { personJsonLd } from "@/config/jsonld"
 
 const { t } = useI18n()
 const age = useAge(new Date("1995-03-05"))
@@ -46,22 +45,12 @@ useRouteSeo({
   path: "/"
 })
 
-const personJsonLd = computed(() => ({
-  "@context": "https://schema.org",
-  "@type": "Person",
-  name: "Antoine Steyer",
-  url: SITE_URL,
-  jobTitle: t("seo.jobTitle"),
-  description: t("seo.personDescription"),
-  address: { "@type": "PostalAddress", addressLocality: "Valence", addressCountry: "FR" },
-  sameAs: ["https://www.linkedin.com/in/antsteyer/", "https://github.com/antsteyer"]
-}))
-
 useHead({
   script: [
     {
+      key: "person-jsonld",
       type: "application/ld+json",
-      innerHTML: computed(() => JSON.stringify(personJsonLd.value))
+      innerHTML: JSON.stringify(personJsonLd)
     }
   ]
 })


### PR DESCRIPTION
Closes #57.

## Summary

- the `Person` JSON-LD was rendered twice (FR + EN) once the page hydrated, because the `useHead` `script` entry had no `key` for unhead to reconcile the SSR tag with the client one
- extract the JSON-LD payload to `src/config/jsonld.ts` and freeze it on the default locale (FR) — JSON-LD is consumed by crawlers and should describe a single canonical entity regardless of the visitor's browser language
- add `key: "person-jsonld"` on the `useHead` script entry so unhead reconciles SSR and client tags into one

## Test plan

- [x] `bun run lint:check` and `bun run format:check` pass
- [x] `bun run build` succeeds; `dist/index.html` contains exactly one `application/ld+json` script (verified with `grep -c`), with `data-hid="person-jsonld"` proving the dedupe key was applied
- [x] the JSON-LD content is the FR version regardless of the navigator language
- [ ] post-deploy: `validator.schema.org` shows a single `Person` entity on the home page
- [ ] post-deploy: `curl -s https://antoinesteyer.com | grep -c "application/ld+json"` returns `1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)